### PR TITLE
Add default --group to new-invite.sh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Check that your Snikket login page loads at `http://<your domain>/`
 To create your first account, create an invitation with:
 
 ```
-./scripts/new-invite.sh --admin
+./scripts/new-invite.sh --admin --group default
 ```
 
 Open the link in a browser. If you are on a desktop, you can use


### PR DESCRIPTION
This will make sure that the freshly minted admin is also in the
default circle to achieve the intended user experience.