### PR TITLE
point user to correct script location after running ./scripts/init.sh

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -105,6 +105,6 @@ sed \
   snikket.conf.example > snikket.conf
 
 echo ""
-echo 'Success! Your configuration has been saved. You may now run ./start.sh'
+echo 'Success! Your configuration has been saved. You may now run ./scripts/start.sh'
 
 exit 0;


### PR DESCRIPTION
Hi,

after running ./scripts/init.sh (as written in readme.md), the script will aske the user to run ./start.sh - which does not exist inside the root of the git repo. 

Just fixed the path to prevent confusion.

brs