### PR TITLE
Force snikket-web-portal to listen on 127.0.0.1 only

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -24,7 +24,10 @@ services:
     network_mode: host
     env_file: snikket.conf
     restart: "unless-stopped"
-
+    environment:
+      # Do not expose the HTTP server inside the container to the outside
+      # world (see use of network_mode: host above).
+      - SNIKKET_TWEAK_PORTAL_INTERNAL_HTTP_INTERFACE=127.0.0.1
   snikket_server:
     container_name: snikket
     image: snikket/snikket-server:beta


### PR DESCRIPTION
This is in preparation for changing the default to a more
docker-like 0.0.0.0. While deployment with 0.0.0.0 is not
supported, it is useful in development use cases.