### PR TITLE
Switch to Debian 11 for images used in backups

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,4 +17,4 @@ if [ ! -d "$1" ]; then
 	exit 1;
 fi
 
-exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:buster-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket
+exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:bullseye-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -36,5 +36,5 @@ exec docker run \
   --rm \
   --volumes-from=snikket \
   --mount type=bind,source="$1",destination=/backup.tar.gz \
-  debian:buster-slim \
+  debian:bullseye-slim \
   bash -c "rm -rf /snikket/*; tar xvf /backup.tar.gz -C /"


### PR DESCRIPTION
Saves space since the Snikket components are now based on bullseye, so
the buster image can be pruned.

Thanks p42ity for pointing out