### PR TITLE
Update container images to Debian 12 Bookworm

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,4 +17,4 @@ if [ ! -d "$1" ]; then
 	exit 1;
 fi
 
-exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:buster-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket
+exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:bullseye-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,4 +17,4 @@ if [ ! -d "$1" ]; then
 	exit 1;
 fi
 
-exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:bullseye-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket
+exec docker run --rm --volumes-from=snikket -v "$1":/backup debian:bookworm-slim tar czf /backup/snikket-"$(date +%F-%R)".tar.gz /snikket

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -36,5 +36,5 @@ exec docker run \
   --rm \
   --volumes-from=snikket \
   --mount type=bind,source="$1",destination=/backup.tar.gz \
-  debian:buster-slim \
+  debian:bullseye-slim \
   bash -c "rm -rf /snikket/*; tar xvf /backup.tar.gz -C /"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -36,5 +36,5 @@ exec docker run \
   --rm \
   --volumes-from=snikket \
   --mount type=bind,source="$1",destination=/backup.tar.gz \
-  debian:bullseye-slim \
+  debian:bookworm-slim \
   bash -c "rm -rf /snikket/*; tar xvf /backup.tar.gz -C /"


### PR DESCRIPTION
Snikket server etc uses Debian 12 as base image, but these scripts still use Debian 10. This leads to downloading an unnecessary extra image that takes up more space on users systems.

- [ ] Tested

Replaces #7 